### PR TITLE
fix: block additional unsafe IP ranges

### DIFF
--- a/apps/web/src/middleware/ipSafe.spec.ts
+++ b/apps/web/src/middleware/ipSafe.spec.ts
@@ -65,6 +65,30 @@ describe('IP Safe Tests', () => {
     expect(ipSafe('127.0.0.1')).toBe(false);
   });
 
+  test('returns false for IPv4 multicast address', () => {
+    const mockIPv4 = {
+      kind: () => 'ipv4',
+      range: () => 'multicast',
+      toString: () => '224.0.0.1',
+      match: () => true,
+    };
+    (ipaddr.parse as jest.Mock).mockReturnValueOnce(mockIPv4);
+
+    expect(ipSafe('224.0.0.1')).toBe(false);
+  });
+
+  test('returns false for IPv4 carrier-grade NAT address', () => {
+    const mockIPv4 = {
+      kind: () => 'ipv4',
+      range: () => 'carrierGradeNat',
+      toString: () => '100.64.0.1',
+      match: () => true,
+    };
+    (ipaddr.parse as jest.Mock).mockReturnValueOnce(mockIPv4);
+
+    expect(ipSafe('100.64.0.1')).toBe(false);
+  });
+
   test('returns true for safe IPv4 address', () => {
     const mockIPv4 = {
       kind: () => 'ipv4',
@@ -87,6 +111,18 @@ describe('IP Safe Tests', () => {
     (ipaddr.parse as jest.Mock).mockReturnValueOnce(mockIPv6);
 
     expect(ipSafe('::1')).toBe(false);
+  });
+
+  test('returns false for IPv6 multicast address', () => {
+    const mockIPv6 = {
+      kind: () => 'ipv6',
+      range: () => 'multicast',
+      isIPv4MappedAddress: () => false,
+      match: () => true,
+    };
+    (ipaddr.parse as jest.Mock).mockReturnValueOnce(mockIPv6);
+
+    expect(ipSafe('ff00::1')).toBe(false);
   });
 
   test('returns true for safe IPv6 address', () => {

--- a/apps/web/src/middleware/ipSafe.ts
+++ b/apps/web/src/middleware/ipSafe.ts
@@ -42,8 +42,19 @@ function ipv4Safe(ip: ipaddr.IPv4): boolean {
 
   const range = ip.range();
 
-  // Reject private, link-local, loopback, or broadcast IPs
-  if (['private', 'linkLocal', 'loopback', 'broadcast'].includes(range)) {
+  // Reject private, link-local, loopback, broadcast, or other non-public IPs
+  if (
+    [
+      'private',
+      'linkLocal',
+      'loopback',
+      'broadcast',
+      'unspecified',
+      'multicast',
+      'carrierGradeNat',
+      'reserved',
+    ].includes(range)
+  ) {
     return false;
   }
 
@@ -61,9 +72,13 @@ function ipv6Safe(ip: ipaddr.IPv6): boolean {
     return ipv4Safe(ipv4);
   }
 
-  // Reject loopback, unspecified, link-local, or unique-local IPs
+  // Reject loopback, unspecified, link-local, unique-local, or multicast IPs
   const range = ip.range();
-  if (['loopback', 'unspecified', 'linkLocal', 'uniqueLocal'].includes(range)) {
+  if (
+    ['loopback', 'unspecified', 'linkLocal', 'uniqueLocal', 'multicast'].includes(
+      range,
+    )
+  ) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- reject IPv4 multicast, carrier-grade NAT, unspecified, reserved, and IPv6 multicast addresses
- add unit tests covering multicast and carrier-grade NAT scenarios

## Testing
- `yarn lint`
- `yarn test`